### PR TITLE
mariadb to skysql provider change, [MTST-288]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# MariaDB SkySQL Terraform Provider
+# SkySQL Terraform Provider
 
-> The MariaDB SkySQL Terraform Provider is a Technical Preview. Software in Tech Preview should not be used for production workloads.
+> The SkySQL Terraform Provider is a Technical Preview. Software in Tech Preview should not be used for production workloads.
 
-This is a Terraform provider for managing resources in [MariaDB SkySQL](https://mariadb.com/products/skysql/).
+This is a Terraform provider for managing resources in [SkySQL](https://www.skysql.com).
 
 See the examples in `/docs` in this repository for usage examples.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
-page_title: "MariaDB SkySQL Terraform Provider"
+page_title: "SkySQL Terraform Provider"
 description: |-
-   The MariaDB SkySQL Terraform Provider allows database services in MariaDB SkySQL to be managed using Terraform.
+   The SkySQL Terraform Provider allows database services in SkySQL to be managed using Terraform.
 ---
 
 # SKYSQL-BETA Provider
@@ -14,7 +14,7 @@ The provider allows configuring any SkySQL DB topology using the Terraform's dec
 
 [Terraform](https://www.terraform.io/) is an open source infrastructure-as-code (IaC) utility.
 
-Alternatively, SkySQL services can be managed interactively the [SkySQL Portal](https://skysql.mariadb.com/dashboard) or the SkySQL REST API.
+Alternatively, SkySQL services can be managed interactively the [SkySQL Portal](https://app.skysql.com/dashboard) or the SkySQL REST API.
 
 Use the navigation to the left to read about the available resources.
 
@@ -89,14 +89,14 @@ The following examples use Bash on Linux (x64).
 3. Copy the plugin to a target system and move to the Terraform plugins directory.
 
     ```console
-    mv terraform-provider-skysql-beta_${RELEASE}_${OS}_${ARCH}.zip ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/skysql-beta
+    mv terraform-provider-skysql-beta_${RELEASE}_${OS}_${ARCH}.zip ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/skysql-beta/
 
     ```
 
 4. Verify the presence of the plugin in the Terraform plugins directory.
 
     ```console
-    ls ~/.terraform.d/plugins/local/skysqlinc/skysql-beta/
+    ls ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/skysql-beta/
     ```
 
 #### macOS
@@ -137,7 +137,7 @@ The following example uses Bash (default) on macOS (ARM).
 5. Verify the presence of the plugin in the Terraform plugins directory.
 
     ```console
-    ls ~/.terraform.d/plugins/local/skysqlinc/skysql-beta/
+    ls ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/skysql-beta/
     ```
 
 ## Configure the Terraform Configuration Files
@@ -218,7 +218,6 @@ data "skysql_versions" "default" {
   topology = "es-single"
 }
 
-
 # Retrieve the list of projects. Project is a way of grouping the services.
 # Note: Next release will make project_id optional in the create service api
 data "skysql_projects" "default" {}
@@ -241,8 +240,8 @@ resource "skysql_service" "default" {
   ssl_enabled    = true
   version        = data.skysql_versions.default.versions[0].name
   # [Optional] Below you can find example with optional parameters how to configure a privatelink connection
-  endpoint_mechanism        = "privatelink"
-  endpoint_allowed_accounts = ["gcp-project-id"]
+  # endpoint_mechanism        = "privatelink"
+  # endpoint_allowed_accounts = ["gcp-project-id"]
   # [/Optional]
   # The service create is an asynchronous operation.
   # if you want to wait for the service to be created set wait_for_creation to true
@@ -250,7 +249,7 @@ resource "skysql_service" "default" {
   # You need to add your ip address in the CIRD format to allow list in order to connect to the service
   allow_list = [
     {
-      "ip" : "104.28.203.45/32",
+      "ip" : "1.1.1.1/32",
       "comment" : "homeoffice"
     }
   ]
@@ -278,10 +277,9 @@ output "skysql_credentials" {
   sensitive = true
 }
 
-
 # Example how you can generate a command line for the database connection
 output "skysql_cmd" {
-  value = "mariadb --host ${data.skysql_service.default.fqdn} --port 3306 --user ${data.skysql_service.default.service_id} -p --ssl-ca ~/Downloads/skysql_chain_2022.pem"
+  value = "mariadb --host ${data.skysql_service.default.fqdn} --port 3306 --user ${data.skysql_service.default.service_id} -p --ssl-verify-server-cert"
 }
 ```
 
@@ -294,24 +292,14 @@ If you agree with the changes, run `terraform apply` to create the service.
 
 Obtain the connection credentials for the new SkySQL service by executing the following commands:
 
-1. Download [skysql_chain_2022.pem](https://supplychain.mariadb.com/skysql/skysql_chain_2022.pem), which contains the Certificate Authority chain that is used to verify the server's certificate for TLS:
-
-```bash
-$ curl https://supplychain.mariadb.com/skysql/skysql_chain_2022.pem --output ~/Downloads/skysql_chain_2022.pem
-```
-
-2. Obtain the connection command from the terraform.tfstate file:
-
+1. Obtain the connection command from the terraform.tfstate file:
 ```bash
 $ jq ".outputs.skysql_cmd" terraform.tfstate
 ```
-3. Obtain the user password from the terraform.tfstate file:
 
+2. Obtain the user password from the terraform.tfstate file:
 ```bash
 $ jq ".outputs.skysql_credentials.value.password" terraform.tfstate
-```
-```bash
-"..password string.."
 ```
 
 ## Connect to the SkySQL service
@@ -319,7 +307,7 @@ $ jq ".outputs.skysql_credentials.value.password" terraform.tfstate
 Connect to the SkySQL service by executing the connection command from the previous step:
 
 ```bash
-$ mariadb --host dbtgf06833805.sysp0000.db.skysql.net --port 3306 --user dbtgf06833805 -p --ssl-ca ~/Downloads/skysql_chain_2022.pem
+$ mariadb --host dbtgf06833805.sysp0000.db.skysql.net --port 3306 --user dbtgf06833805 -p --ssl-verify-server-cert
 ```
 
 When prompted, type the password and press enter to connect:

--- a/examples/global-replication/main.tf
+++ b/examples/global-replication/main.tf
@@ -89,7 +89,7 @@ resource "skysql_allow_list" "default" {
   service_id = skysql_service.primary.id
   allow_list = [
     {
-      "ip" : "104.28.203.45/32",
+      "ip" : "1.1.1.1/32",
       "comment" : "homeoffice"
     }
   ]
@@ -98,7 +98,7 @@ resource "skysql_allow_list" "default" {
 
 # Example how you can generate a command line for the database connection
 output "skysql_cmd" {
-  value = "mariadb --host ${data.skysql_service.default.fqdn} --port 3306 --user ${data.skysql_service.default.service_id} -p --ssl-ca ~/Downloads/skysql_chain_2022.pem"
+  value = "mariadb --host ${data.skysql_service.default.fqdn} --port 3306 --user ${data.skysql_service.default.service_id} -p --ssl-verify-server-cert"
 }
 
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -5,7 +5,6 @@ data "skysql_versions" "default" {
   topology = "es-single"
 }
 
-
 # Retrieve the list of projects. Project is a way of grouping the services.
 # Note: Next release will make project_id optional in the create service api
 data "skysql_projects" "default" {}
@@ -28,8 +27,8 @@ resource "skysql_service" "default" {
   ssl_enabled    = true
   version        = data.skysql_versions.default.versions[0].name
   # [Optional] Below you can find example with optional parameters how to configure a privatelink connection
-  endpoint_mechanism        = "privatelink"
-  endpoint_allowed_accounts = ["gcp-project-id"]
+  # endpoint_mechanism        = "privatelink"
+  # endpoint_allowed_accounts = ["gcp-project-id"]
   # [/Optional]
   # The service create is an asynchronous operation.
   # if you want to wait for the service to be created set wait_for_creation to true
@@ -37,7 +36,7 @@ resource "skysql_service" "default" {
   # You need to add your ip address in the CIRD format to allow list in order to connect to the service
   allow_list = [
     {
-      "ip" : "104.28.203.45/32",
+      "ip" : "1.1.1.1/32",
       "comment" : "homeoffice"
     }
   ]
@@ -65,8 +64,7 @@ output "skysql_credentials" {
   sensitive = true
 }
 
-
 # Example how you can generate a command line for the database connection
 output "skysql_cmd" {
-  value = "mariadb --host ${data.skysql_service.default.fqdn} --port 3306 --user ${data.skysql_service.default.service_id} -p --ssl-ca ~/Downloads/skysql_chain_2022.pem"
+  value = "mariadb --host ${data.skysql_service.default.fqdn} --port 3306 --user ${data.skysql_service.default.service_id} -p --ssl-verify-server-cert"
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -65,7 +65,7 @@ func getEnv(key, fallback string) string {
 
 func (p *skySQLProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	accessToken := os.Getenv("TF_SKYSQL_API_ACCESS_TOKEN")
-	baseURL := getEnv("TF_SKYSQL_API_BASE_URL", "https://api.mariadb.com")
+	baseURL := getEnv("TF_SKYSQL_API_BASE_URL", "https://api.skysql.com")
 
 	var data SkySQLProviderModel
 

--- a/internal/provider/service_resource_privatlink_test.go
+++ b/internal/provider/service_resource_privatlink_test.go
@@ -119,7 +119,7 @@ func TestServiceResourcePrivateLink(t *testing.T) {
 		service.Endpoints[0].Mechanism = "privatelink"
 		service.Endpoints[0].AllowedAccounts = []string{"mdb-cnewport"}
 		service.Endpoints[0].Visibility = "private"
-		service.Endpoints[0].EndpointService = "privatelink.mariadb.com"
+		service.Endpoints[0].EndpointService = "privatelink.skysql.com"
 		json.NewEncoder(w).Encode(&provisioning.PatchServiceEndpointsResponse{
 			{
 				Mechanism:       service.Endpoints[0].Mechanism,

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,7 +1,7 @@
 ---
-page_title: "MariaDB SkySQL Terraform Provider"
+page_title: "SkySQL Terraform Provider"
 description: |-
-   The MariaDB SkySQL Terraform Provider allows database services in MariaDB SkySQL to be managed using Terraform.
+   The SkySQL Terraform Provider allows database services in SkySQL to be managed using Terraform.
 ---
 
 # {{ .ProviderShortName | upper }} Provider
@@ -14,7 +14,7 @@ The provider allows configuring any SkySQL DB topology using the Terraform's dec
 
 [Terraform](https://www.terraform.io/) is an open source infrastructure-as-code (IaC) utility.
 
-Alternatively, SkySQL services can be managed interactively the [SkySQL Portal](https://skysql.mariadb.com/dashboard) or the SkySQL REST API.
+Alternatively, SkySQL services can be managed interactively the [SkySQL Portal](https://app.skysql.com/dashboard) or the SkySQL REST API.
 
 Use the navigation to the left to read about the available resources.
 
@@ -89,14 +89,14 @@ The following examples use Bash on Linux (x64).
 3. Copy the plugin to a target system and move to the Terraform plugins directory.
 
     ```console
-    mv {{.ProviderName}}_${RELEASE}_${OS}_${ARCH}.zip ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/{{.ProviderShortName}}
+    mv {{.ProviderName}}_${RELEASE}_${OS}_${ARCH}.zip ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/{{.ProviderShortName}}/
 
     ```
 
 4. Verify the presence of the plugin in the Terraform plugins directory.
 
     ```console
-    ls ~/.terraform.d/plugins/local/skysqlinc/{{.ProviderShortName}}/
+    ls ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/{{.ProviderShortName}}/
     ```
 
 #### macOS
@@ -137,7 +137,7 @@ The following example uses Bash (default) on macOS (ARM).
 5. Verify the presence of the plugin in the Terraform plugins directory.
 
     ```console
-    ls ~/.terraform.d/plugins/local/skysqlinc/{{.ProviderShortName}}/
+    ls ~/.terraform.d/plugins/registry.terraform.io/skysqlinc/{{.ProviderShortName}}/
     ```
 
 ## Configure the Terraform Configuration Files
@@ -221,24 +221,14 @@ If you agree with the changes, run `terraform apply` to create the service.
 
 Obtain the connection credentials for the new SkySQL service by executing the following commands:
 
-1. Download [skysql_chain_2022.pem](https://supplychain.mariadb.com/skysql/skysql_chain_2022.pem), which contains the Certificate Authority chain that is used to verify the server's certificate for TLS:
-
-```bash
-$ curl https://supplychain.mariadb.com/skysql/skysql_chain_2022.pem --output ~/Downloads/skysql_chain_2022.pem
-```
-
-2. Obtain the connection command from the terraform.tfstate file:
-
+1. Obtain the connection command from the terraform.tfstate file:
 ```bash
 $ jq ".outputs.skysql_cmd" terraform.tfstate
 ```
-3. Obtain the user password from the terraform.tfstate file:
 
+2. Obtain the user password from the terraform.tfstate file:
 ```bash
 $ jq ".outputs.skysql_credentials.value.password" terraform.tfstate
-```
-```bash
-"..password string.."
 ```
 
 ## Connect to the SkySQL service
@@ -246,7 +236,7 @@ $ jq ".outputs.skysql_credentials.value.password" terraform.tfstate
 Connect to the SkySQL service by executing the connection command from the previous step:
 
 ```bash
-$ mariadb --host dbtgf06833805.sysp0000.db.skysql.net --port 3306 --user dbtgf06833805 -p --ssl-ca ~/Downloads/skysql_chain_2022.pem
+$ mariadb --host dbtgf06833805.sysp0000.db.skysql.net --port 3306 --user dbtgf06833805 -p --ssl-verify-server-cert
 ```
 
 When prompted, type the password and press enter to connect:


### PR DESCRIPTION
Before we can register a public TF provider, we need to make sure the provider works with our system.  This change:

* Replaced all obvious instances of mariadb.com reference, such as api.mariadb.com and renamed them to api.skysql.com
* Saw we had our cloudflare ip listed as part of the examples, changed that to a `1.1.1.1`
* Tested the provider by building locally, and deploying a database instance to our test environment.

my test.tf
```
terraform {
  required_providers {
    skysql = {
      source = "registry.terraform.io/skysqlinc/skysql-beta"
      version = ">= 0.4.9"
    }
  }
}

provider "skysql" {}

# Retrieve the list of available versions for each topology like standalone, masterslave, xpand-direct etc
data "skysql_versions" "default" {
  topology = "es-single"
}

# Retrieve the list of projects. Project is a way of grouping the services.
# Note: Next release will make project_id optional in the create service api
data "skysql_projects" "default" {

}

output "skysql_projects" {
  value = data.skysql_projects.default
}

# Create a service
resource "skysql_service" "default" {
  service_type   = "transactional"
  topology       = "es-single"
  cloud_provider = "gcp"
  region         = "us-central1"
  name           = "myservice"
  deletion_protection = true
  architecture   = "amd64"
  nodes          = 1
  size           = "sky-2x8"
  storage        = 100
  ssl_enabled    = true
  version        = data.skysql_versions.default.versions[0].name
  # [Optional] Below you can find example with optional parameters how to configure a privatelink connection
  # endpoint_mechanism        = "privatelink"
  # endpoint_allowed_accounts = ["test-skysql-infra-406507"]
  # [/Optional]
  # The service create is an asynchronous operation.
  # if you want to wait for the service to be created set wait_for_creation to true
  wait_for_creation = true
  # You need to add your ip address in the CIRD format to allow list in order to connect to the service
  allow_list = [
    {
      "ip" : "1.1.1.1/32",
      "comment" : "homeoffice"
    }
  ]
}

# Retrieve the service default credentials.
# When the service is created please change the default credentials
data "skysql_credentials" "default" {
  service_id = skysql_service.default.id
}

# Retrieve the service details
data "skysql_service" "default" {
  service_id = skysql_service.default.id
}

# Show the service details
output "skysql_service" {
  value = data.skysql_service.default
}

# Show the service credentials
output "skysql_credentials" {
  value     = data.skysql_credentials.default
  sensitive = true
}


# Example how you can generate a command line for the database connection
output "skysql_cmd" {
  value = "mariadb --host ${data.skysql_service.default.fqdn} --port 3306 --user ${data.skysql_service.default.service_id} -p --ssl-ca ~/Downloads/skysql_chain_2022.pem"
}

```
 
 
<img width="1041" alt="image" src="https://github.com/skysqlinc/terraform-provider-skysql-beta/assets/156709221/9efd607b-76ac-4c97-af23-65ab54d08efc">
