### PR TITLE
[v3.5.2-beta] 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.5.2-beta] - 2026-04-06
+### Fixed
+- `ssl_enabled` can now be toggled on an existing service in-place without requiring destroy and recreate ([#45](https://github.com/skysqlinc/terraform-provider-skysql/issues/45)).
+- Improved `ssl_enabled` documentation to explain that it controls TLS encryption for client database connections.
+
 ## [3.5.1-beta] - 2026-04-06
 ### Fixed
 - Fixed `tags` attribute causing perpetual diffs and "Provider produced inconsistent result after apply" errors ([#34](https://github.com/skysqlinc/terraform-provider-skysql/issues/34)).

--- a/docs/resources/skysql_service.md
+++ b/docs/resources/skysql_service.md
@@ -75,7 +75,7 @@ resource "skysql_service" "default" {
 - `project_id` (String) The ID of the project to create the service in
 - `replication_enabled` (Boolean) Whether to enable global replication. Valid values are: true or false. Works for xpand-direct topology only
 - `size` (String) The size of the service. Valid values are: sky-2x4, sky-2x8 etc
-- `ssl_enabled` (Boolean) Whether to enable SSL. Valid values are: true or false
+- `ssl_enabled` (Boolean) Whether to enable SSL/TLS encryption for client connections to the database. When true, the database requires TLS-encrypted connections. Can be toggled on an existing service (the service will be updated in-place). Cannot be toggled for `serverless-standalone` topology.
 - `storage` (Number) The storage size in GB. Valid values are: 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000
 - `tags` (Map of String) User-defined tags for the service. Use tags.name to set a display name (the API sets this to the service name by default on creation). Only the tag keys you specify here are tracked in Terraform state; any server-injected tags are ignored.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -1616,6 +1616,7 @@ func (r *ServiceResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 				"Attempt to modify read-only attribute",
 				fmt.Sprintf("The argument %q is read only for the %q topology", "version", plan.Topology.ValueString()))
 		}
+
 	}
 
 	// Block start/stop and SSL toggle for serverless-standalone services

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -287,9 +287,8 @@ var serviceResourceSchemaV0 = schema.Schema{
 		"ssl_enabled": schema.BoolAttribute{
 			Optional:    true,
 			Computed:    true,
-			Description: "Whether to enable SSL. Valid values are: true or false",
+			Description: "Whether to enable SSL/TLS encryption for client connections to the database. When true, the database requires TLS-encrypted connections. Can be toggled on an existing service (the service will be updated in-place). Cannot be toggled for `serverless-standalone` topology.",
 			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.RequiresReplace(),
 				boolplanmodifier.UseStateForUnknown(),
 			},
 		},
@@ -934,6 +933,11 @@ func (r *ServiceResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	r.updateServiceSSL(ctx, plan, state, resp)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	r.updateServiceConfig(ctx, plan, state, resp)
 	if resp.Diagnostics.HasError() {
 		return
@@ -1023,6 +1027,29 @@ func (r *ServiceResource) updateNumberOfNodeForService(ctx context.Context, plan
 		}
 
 		state.Nodes = plan.Nodes
+		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		r.waitForUpdate(ctx, state, resp)
+	}
+}
+
+func (r *ServiceResource) updateServiceSSL(ctx context.Context, plan *ServiceResourceModel, state *ServiceResourceModel, resp *resource.UpdateResponse) {
+	if plan.SSLEnabled.ValueBool() != state.SSLEnabled.ValueBool() {
+		tflog.Info(ctx, "Updating service SSL", map[string]interface{}{
+			"id":   state.ID.ValueString(),
+			"from": state.SSLEnabled.ValueBool(),
+			"to":   plan.SSLEnabled.ValueBool(),
+		})
+
+		err := r.client.SetServiceSSL(ctx, state.ID.ValueString(), plan.SSLEnabled.ValueBool())
+		if err != nil {
+			resp.Diagnostics.AddError("Error updating service SSL", fmt.Sprintf("Unable to update service SSL, got error: %s", err))
+			return
+		}
+
+		state.SSLEnabled = plan.SSLEnabled
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -1591,7 +1618,7 @@ func (r *ServiceResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 		}
 	}
 
-	// Block start/stop operations for serverless-standalone services
+	// Block start/stop and SSL toggle for serverless-standalone services
 	if plan.Topology.ValueString() == "serverless-standalone" {
 		if state == nil && !plan.IsActive.IsUnknown() {
 			// Prevent setting is_active during creation
@@ -1606,18 +1633,18 @@ func (r *ServiceResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 				"Attempt to modify read-only attribute",
 				"Start/stop operations are not supported for serverless services")
 		}
+
+		if state != nil && plan.SSLEnabled.ValueBool() != state.SSLEnabled.ValueBool() {
+			resp.Diagnostics.AddAttributeError(path.Root("ssl_enabled"),
+				"Attempt to modify read-only attribute",
+				"SSL can't be toggled for serverless services")
+		}
 	}
 
 	if state != nil && plan.Architecture.ValueString() != state.Architecture.ValueString() {
 		resp.Diagnostics.AddError("Cannot change service architecture",
 			"To prevent accidental deletion of data, changing architecture isn't allowed. "+
 				"Please explicitly destroy this service before changing its architecture.")
-	}
-
-	if state != nil && plan.SSLEnabled.ValueBool() != state.SSLEnabled.ValueBool() {
-		resp.Diagnostics.AddError("Cannot change service ssl_enabled",
-			"To prevent accidental deletion of data, changing ssl_enabled isn't allowed. "+
-				"Please explicitly destroy this service before changing its ssl_enabled.")
 	}
 
 	if state != nil && plan.Version.ValueString() != state.Version.ValueString() {

--- a/internal/provider/service_resource_sa_test.go
+++ b/internal/provider/service_resource_sa_test.go
@@ -102,7 +102,7 @@ func TestServiceResourceServerlessAnalytics(t *testing.T) {
 		json.NewEncoder(w).Encode(service)
 		w.WriteHeader(http.StatusCreated)
 	})
-	for i := 0; i < 8; i++ {
+	for i := 0; i < 7; i++ {
 		expectRequest(func(w http.ResponseWriter, req *http.Request) {
 			r.Equal(
 				fmt.Sprintf("%s %s/%s", http.MethodGet, "/provisioning/v1/services", serviceID),
@@ -323,26 +323,6 @@ func TestServiceResourceServerlessAnalytics(t *testing.T) {
 			}
 			   `,
 				ExpectError: regexp.MustCompile(`Attempt to modify read-only attribute`),
-				Destroy:     false,
-			},
-			{
-				Config: `
-			resource "skysql_service" default {
-				  service_type      = "analytical"
-				  topology          = "sa"
-				  cloud_provider    = "aws"
-				  region            = "us-east-2"
-                  ssl_enabled       =  true
-				  name              = "serverless-analytics"
-				  wait_for_creation = true
-				  wait_for_deletion = true
-				  wait_for_update   = true
-				  deletion_protection = false
-                  volume_type = "io1"
-				  volume_iops = 3000
-			}
-			   `,
-				ExpectError: regexp.MustCompile(`Cannot change service ssl_enabled`),
 				Destroy:     false,
 			},
 			{

--- a/internal/provider/service_resource_serverless_standalone_test.go
+++ b/internal/provider/service_resource_serverless_standalone_test.go
@@ -93,7 +93,7 @@ func TestServiceResourceServerlessStandalone_IsActiveReadOnly(t *testing.T) {
 		json.NewEncoder(w).Encode(service)
 	})
 	// Multiple GET requests for service status checks during and after creation
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 5; i++ {
 		expectRequest(func(w http.ResponseWriter, req *http.Request) {
 			r.Equal(http.MethodGet, req.Method)
 			r.Equal(fmt.Sprintf("/provisioning/v1/services/%s", serviceID), req.URL.Path)
@@ -224,6 +224,29 @@ func TestServiceResourceServerlessStandalone_IsActiveReadOnly(t *testing.T) {
 			}
 			   `,
 				ExpectError: regexp.MustCompile(`Start/stop operations are not supported for serverless services`),
+				Destroy:     false,
+			},
+			// Test 4: Attempt to toggle ssl_enabled during update - should fail for serverless-standalone
+			{
+				Config: `
+			resource "skysql_service" default {
+				  service_type      = "transactional"
+				  topology          = "serverless-standalone"
+				  cloud_provider    = "aws"
+				  region            = "us-east-1"
+				  name              = "sls-standalone-test"
+				  wait_for_creation = true
+				  wait_for_deletion = true
+				  wait_for_update   = true
+				  deletion_protection = false
+				  ssl_enabled       = false
+				  size              = "sky-2x8"
+				  storage           = 100
+				  volume_type       = "io1"
+				  volume_iops       = 3000
+			}
+			   `,
+				ExpectError: regexp.MustCompile(`SSL can't be toggled for serverless services`),
 				Destroy:     false,
 			},
 		},

--- a/internal/skysql/client.go
+++ b/internal/skysql/client.go
@@ -224,6 +224,23 @@ func handleError(resp *resty.Response) error {
 	return errors.New(resp.Status())
 }
 
+func (c *Client) SetServiceSSL(ctx context.Context, serviceID string, sslEnabled bool) error {
+	resp, err := c.HTTPClient.R().
+		SetHeader("Accept", "application/json").
+		SetContext(ctx).
+		SetBody(&provisioning.SetSSLRequest{SSLEnabled: sslEnabled}).
+		SetError(&ErrorResponse{}).
+		Patch("/provisioning/v1/services/" + serviceID + "/security/ssl")
+	if err != nil {
+		return err
+	}
+	if resp.IsError() {
+		return handleError(resp)
+	}
+
+	return err
+}
+
 func (c *Client) SetServicePowerState(ctx context.Context, serviceID string, isActive bool) error {
 	resp, err := c.HTTPClient.R().
 		SetHeader("Accept", "application/json").

--- a/internal/skysql/provisioning/set_ssl_request.go
+++ b/internal/skysql/provisioning/set_ssl_request.go
@@ -1,0 +1,5 @@
+package provisioning
+
+type SetSSLRequest struct {
+	SSLEnabled bool `json:"ssl_enabled"`
+}


### PR DESCRIPTION
The PR description I gave was just text output — not committed anywhere. Let me fix it:

## feat: support in-place `ssl_enabled` toggle via DPS API (#45)

### Summary

`ssl_enabled` can now be toggled on an existing service without requiring destroy and recreate. The provider calls `PATCH /provisioning/v1/services/{id}/security/ssl` to update SSL in-place.

### Problem

Users changing `ssl_enabled` on an existing service were blocked with:
> "To prevent accidental deletion of data, changing ssl_enabled isn't allowed. Please explicitly destroy this service before changing its ssl_enabled."

The DPS API has supported non-destructive SSL toggling all along — the provider was unnecessarily restrictive.

### Testing

- Both providers compile cleanly
- `serverless-standalone` topology correctly blocked at plan time with clear error message

Closes #45