### PR TITLE
[v3.5.2] docs: document ssl_enabled

### DIFF
--- a/docs/resources/skysql_service.md
+++ b/docs/resources/skysql_service.md
@@ -76,6 +76,8 @@ resource "skysql_service" "default" {
 - `replication_enabled` (Boolean) Whether to enable global replication. Valid values are: true or false. Works for xpand-direct topology only
 - `size` (String) The size of the service. Valid values are: sky-2x4, sky-2x8 etc
 - `ssl_enabled` (Boolean) Whether to enable SSL/TLS encryption for client connections to the database. When true, the database requires TLS-encrypted connections. Can be toggled on an existing service (the service will be updated in-place). Cannot be toggled for `serverless-standalone` topology.
+
+**Important:** Toggling this flag controls whether the server or proxy offers TLS, but it does not modify the default database user's grants. The default user is created with `REQUIRE SSL`. For topologies that use MaxScale (e.g., `es-replica`), this is not an issue because MaxScale terminates TLS independently. For topologies without MaxScale (e.g., `es-single`), disabling SSL will prevent the default user from connecting because the user still requires SSL at the database level. To connect after disabling SSL on a non-MaxScale topology, first run `ALTER USER '<username>'@'%' REQUIRE NONE` while SSL is still enabled.
 - `storage` (Number) The storage size in GB. Valid values are: 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000
 - `tags` (Map of String) User-defined tags for the service. Use tags.name to set a display name (the API sets this to the service name by default on creation). Only the tag keys you specify here are tracked in Terraform state; any server-injected tags are ignored.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/internal/provider/service_resource.go
+++ b/internal/provider/service_resource.go
@@ -285,9 +285,13 @@ var serviceResourceSchemaV0 = schema.Schema{
 			},
 		},
 		"ssl_enabled": schema.BoolAttribute{
-			Optional:    true,
-			Computed:    true,
-			Description: "Whether to enable SSL/TLS encryption for client connections to the database. When true, the database requires TLS-encrypted connections. Can be toggled on an existing service (the service will be updated in-place). Cannot be toggled for `serverless-standalone` topology.",
+			Optional: true,
+			Computed: true,
+			Description: "Whether to enable SSL/TLS encryption for client connections to the database. When true, the database requires TLS-encrypted connections. Can be toggled on an existing service (the service will be updated in-place). Cannot be toggled for `serverless-standalone` topology.\n\n" +
+				"**Important:** Toggling this flag controls whether the server or proxy offers TLS, but it does not modify the default database user's grants. " +
+				"The default user is created with `REQUIRE SSL`. For topologies that use MaxScale (e.g., `es-replica`), this is not an issue because MaxScale terminates TLS independently. " +
+				"For topologies without MaxScale (e.g., `es-single`), disabling SSL will prevent the default user from connecting because the user still requires SSL at the database level. " +
+				"To connect after disabling SSL on a non-MaxScale topology, first run `ALTER USER '<username>'@'%' REQUIRE NONE` while SSL is still enabled.",
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},


### PR DESCRIPTION
[v3.5.2] docs: document ssl_enabled REQUIRE SSL behavior for non-MaxScale topologies

The default database user is created with REQUIRE SSL, but toggling ssl_enabled does not update user grants. For topologies without MaxScale (e.g., es-single), disabling SSL prevents the default user from connecting. Added this caveat to the ssl_enabled attribute description and regenerated docs.