### PR TITLE
[v3.5.4] fix: broken HTTP retry logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.5.4-beta] - 2026-04-09
+### Fixed
+- Fixed broken HTTP retry logic — transient 5xx errors were never retried despite retry configuration.
+- Added 429 rate-limit handling with `Retry-After` header support.
+- Improved error messages to include API response details instead of generic "500 Internal Server Error".
+
 ## [3.5.3-beta] - 2026-04-08
 ### Reverted
 - Reverted `ssl_enabled` changes from 3.5.2-beta. The feature is not fully implemented yet and will be completed in a future release.

--- a/internal/provider/service_resource_test.go
+++ b/internal/provider/service_resource_test.go
@@ -286,6 +286,15 @@ resource "skysql_service" default {
 					w.Header().Set("Content-Type", "application/json")
 					w.WriteHeader(http.StatusInternalServerError)
 				})
+				// The client retries 500s up to 3 times.
+				for range 3 {
+					expectRequest(func(w http.ResponseWriter, req *http.Request) {
+						r.Equal(http.MethodPost, req.Method)
+						r.Equal("/provisioning/v1/services", req.URL.Path)
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusInternalServerError)
+					})
+				}
 			},
 			checks: []resource.TestCheckFunc{
 				resource.TestCheckResourceAttr("skysql_service.default", "id", serviceID),

--- a/internal/skysql/client.go
+++ b/internal/skysql/client.go
@@ -2,7 +2,7 @@ package skysql
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -38,23 +38,40 @@ func New(baseURL string, apiKey string, orgID string) *Client {
 
 	return &Client{
 		HTTPClient: httpClient.
-			// Set retry count too non-zero to enable retries
+			// Set retry count to non-zero to enable retries.
 			SetRetryCount(3).
 			// Default is 100 milliseconds.
 			SetRetryWaitTime(5 * time.Second).
 			// MaxWaitTime can be overridden as well.
 			// Default is 2 seconds.
 			SetRetryMaxWaitTime(20 * time.Second).
-			// SetRetryAfter sets callback to calculate wait time between retries.
-			// Default (nil) implies exponential backoff with jitter
+			// Honor Retry-After header on 429 responses;
+			// fall back to default exponential backoff with jitter.
 			SetRetryAfter(func(client *resty.Client, resp *resty.Response) (time.Duration, error) {
-				return 0, errors.New("retries quota exceeded")
+				if resp.StatusCode() == http.StatusTooManyRequests {
+					if ra := resp.Header().Get("Retry-After"); ra != "" {
+						if seconds, err := strconv.Atoi(ra); err == nil {
+							return time.Duration(seconds) * time.Second, nil
+						}
+					}
+				}
+				// Return 0 to let resty use its default backoff.
+				return 0, nil
 			}).
 			AddRetryCondition(
-				// RetryConditionFunc type is for retry condition function
-				// input: non-nil Response OR request execution error
 				func(r *resty.Response, err error) bool {
-					return r.StatusCode() == http.StatusInternalServerError
+					if err != nil {
+						return true
+					}
+					switch r.StatusCode() {
+					case http.StatusTooManyRequests,
+						http.StatusInternalServerError,
+						http.StatusBadGateway,
+						http.StatusServiceUnavailable,
+						http.StatusGatewayTimeout:
+						return true
+					}
+					return false
 				}).
 			EnableTrace(),
 	}
@@ -215,13 +232,12 @@ func handleError(resp *resty.Response) error {
 		return ErrorUnauthorized
 	}
 	if resp.Error() != nil {
-		if resp.StatusCode() == 500 {
-			return errors.New("SkySQL API returned 500 Internal Server Error")
+		errResp, ok := resp.Error().(*ErrorResponse)
+		if ok && len(errResp.Errors) > 0 {
+			return fmt.Errorf("SkySQL API %d: %s", resp.StatusCode(), errResp.Errors[0].Message)
 		}
-		errResp := resp.Error().(*ErrorResponse)
-		return errors.New(errResp.Errors[0].Message)
 	}
-	return errors.New(resp.Status())
+	return fmt.Errorf("SkySQL API error: %s", resp.Status())
 }
 
 func (c *Client) SetServicePowerState(ctx context.Context, serviceID string, isActive bool) error {

--- a/internal/skysql/client_test.go
+++ b/internal/skysql/client_test.go
@@ -1,9 +1,14 @@
 package skysql
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestNew_WithOrgID_SetsHeader(t *testing.T) {
@@ -111,5 +116,322 @@ func TestNew_OrgIDHeaderSentOnAllRequests(t *testing.T) {
 		if h != "org-multi" {
 			t.Errorf("request %d: expected X-MDB-Org = %q, got %q", i, "org-multi", h)
 		}
+	}
+}
+
+func TestRetryOn500(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{
+			Errors: []ErrorDetails{{Message: "transient failure"}},
+		})
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(time.Millisecond)
+
+	_, err := client.GetServiceByID(t.Context(), "svc-123")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// 1 initial + 3 retries = 4 total attempts.
+	got := atomic.LoadInt32(&attempts)
+	if got != 4 {
+		t.Errorf("expected 4 attempts (1 + 3 retries), got %d", got)
+	}
+}
+
+func TestRetryOn502(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(time.Millisecond)
+
+	_, err := client.GetServiceByID(t.Context(), "svc-123")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	got := atomic.LoadInt32(&attempts)
+	if got != 4 {
+		t.Errorf("expected 4 attempts for 502, got %d", got)
+	}
+}
+
+func TestRetryOn503(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(time.Millisecond)
+
+	_, err := client.GetServiceByID(t.Context(), "svc-123")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	got := atomic.LoadInt32(&attempts)
+	if got != 4 {
+		t.Errorf("expected 4 attempts for 503, got %d", got)
+	}
+}
+
+func TestRetryOn504(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusGatewayTimeout)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(time.Millisecond)
+
+	_, err := client.GetServiceByID(t.Context(), "svc-123")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	got := atomic.LoadInt32(&attempts)
+	if got != 4 {
+		t.Errorf("expected 4 attempts for 504, got %d", got)
+	}
+}
+
+func TestRetrySucceedsAfterTransientFailure(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(ErrorResponse{
+				Errors: []ErrorDetails{{Message: "transient"}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":     "svc-123",
+			"name":   "test-service",
+			"status": "ready",
+		})
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(time.Millisecond)
+
+	svc, err := client.GetServiceByID(t.Context(), "svc-123")
+	if err != nil {
+		t.Fatalf("expected success after retries, got error: %v", err)
+	}
+	if svc.ID != "svc-123" {
+		t.Errorf("expected service ID svc-123, got %s", svc.ID)
+	}
+
+	got := atomic.LoadInt32(&attempts)
+	if got != 3 {
+		t.Errorf("expected 3 attempts (2 failures + 1 success), got %d", got)
+	}
+}
+
+func TestRetryOn429(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(time.Millisecond)
+
+	_, err := client.GetServiceByID(t.Context(), "svc-123")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	got := atomic.LoadInt32(&attempts)
+	if got != 4 {
+		t.Errorf("expected 4 attempts for 429, got %d", got)
+	}
+}
+
+func TestRetryOn429HonorsRetryAfterHeader(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":     "svc-123",
+			"name":   "test-service",
+			"status": "ready",
+		})
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	// Use short default wait but the Retry-After header should override.
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(5 * time.Second)
+
+	start := time.Now()
+	svc, err := client.GetServiceByID(t.Context(), "svc-123")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected success after retry, got error: %v", err)
+	}
+	if svc.ID != "svc-123" {
+		t.Errorf("expected service ID svc-123, got %s", svc.ID)
+	}
+
+	got := atomic.LoadInt32(&attempts)
+	if got != 2 {
+		t.Errorf("expected 2 attempts (1 rate-limited + 1 success), got %d", got)
+	}
+
+	// Retry-After: 1 means the client should have waited ~1 second.
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("expected retry to honor Retry-After: 1 (~1s delay), but elapsed was %v", elapsed)
+	}
+}
+
+func TestNoRetryOn400(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ErrorResponse{
+			Errors: []ErrorDetails{{Message: "bad request"}},
+		})
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(time.Millisecond)
+
+	_, err := client.GetServiceByID(t.Context(), "svc-123")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	got := atomic.LoadInt32(&attempts)
+	if got != 1 {
+		t.Errorf("expected exactly 1 attempt for 400 (no retry), got %d", got)
+	}
+}
+
+func TestNoRetryOn404(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(time.Millisecond)
+
+	_, err := client.GetServiceByID(t.Context(), "svc-123")
+	if !errors.Is(err, ErrorServiceNotFound) {
+		t.Errorf("expected ErrorServiceNotFound, got: %v", err)
+	}
+
+	got := atomic.LoadInt32(&attempts)
+	if got != 1 {
+		t.Errorf("expected exactly 1 attempt for 404 (no retry), got %d", got)
+	}
+}
+
+func TestHandleError401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+
+	_, err := client.GetServiceByID(t.Context(), "svc-123")
+	if !errors.Is(err, ErrorUnauthorized) {
+		t.Errorf("expected ErrorUnauthorized, got: %v", err)
+	}
+}
+
+func TestHandleError500IncludesMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(ErrorResponse{
+			Errors: []ErrorDetails{{Message: "database connection pool exhausted"}},
+		})
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(time.Millisecond)
+
+	_, err := client.GetServiceByID(t.Context(), "svc-123")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "database connection pool exhausted") {
+		t.Errorf("expected error to contain API message, got: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected error to contain status code, got: %q", err.Error())
+	}
+}
+
+func TestHandleErrorEmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.HTTPClient.SetRetryWaitTime(time.Millisecond)
+	client.HTTPClient.SetRetryMaxWaitTime(time.Millisecond)
+
+	_, err := client.GetServiceByID(t.Context(), "svc-123")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected error to mention 500, got: %q", err.Error())
 	}
 }


### PR DESCRIPTION
## Summary
- Fix broken HTTP retry logic — `SetRetryAfter` callback was aborting retries immediately, so zero retries ever happened despite configuring 3
- Add 429 rate-limit handling with `Retry-After` header support
- Widen retry condition to cover 429, 500, 502, 503, 504 and network errors (was only 500)
- Fix `handleError` to preserve API error messages on 500s and prevent panic on empty error bodies

## Test plan
- [x] `TestRetryOn500` — verifies 4 attempts on 500
- [x] `TestRetryOn502/503/504` — verifies retries on all server errors
- [x] `TestRetryOn429` — verifies retries on rate limiting
- [x] `TestRetryOn429HonorsRetryAfterHeader` — verifies Retry-After header is respected (~1s delay)
- [x] `TestRetrySucceedsAfterTransientFailure` — 2 failures then success
- [x] `TestNoRetryOn400/404` — client errors not retried
- [x] `TestHandleError500IncludesMessage` — error detail preserved
- [x] `TestHandleErrorEmptyBody` — no panic on empty response
