### PR TITLE
MCDEV-3899: retry service mutations while service is pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.5.5-beta] - 2026-06-17
+### Fixed
+- Concurrent service operations (for example a config change and a scaling operation) no longer conflict. When the API rejects a mutation because the service is in a transient `pending_*` state, the provider now waits for the service to become modifiable and retries instead of failing the apply (MCDEV-3899).
+
 ## [3.5.4-beta] - 2026-04-09
 ### Fixed
 - Fixed broken HTTP retry logic — transient 5xx errors were never retried despite retry configuration.

--- a/internal/skysql/client.go
+++ b/internal/skysql/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -20,6 +21,13 @@ import (
 
 type Client struct {
 	HTTPClient *resty.Client
+
+	// pendingRetryInterval and pendingRetryTimeout control how long mutating
+	// operations wait out a transient "service is in a pending state" rejection
+	// from the backend. Defaulted in New; overridable in tests. See
+	// doWithPendingRetry.
+	pendingRetryInterval time.Duration
+	pendingRetryTimeout  time.Duration
 }
 
 func New(baseURL string, apiKey string, orgID string) *Client {
@@ -74,6 +82,8 @@ func New(baseURL string, apiKey string, orgID string) *Client {
 					return false
 				}).
 			EnableTrace(),
+		pendingRetryInterval: defaultPendingRetryInterval,
+		pendingRetryTimeout:  defaultPendingRetryTimeout,
 	}
 }
 
@@ -186,22 +196,27 @@ func (c *Client) GetServiceCredentialsByID(ctx context.Context, serviceID string
 }
 
 func (c *Client) UpdateServiceAllowListByID(ctx context.Context, serviceID string, allowlist []provisioning.AllowListItem) ([]provisioning.AllowListItem, error) {
-	resp, err := c.HTTPClient.R().
-		SetHeader("Accept", "application/json").
-		SetResult(provisioning.ReadAllowListResponse{}).
-		SetError(&ErrorResponse{}).
-		SetContext(ctx).
-		SetBody(allowlist).
-		Put("/provisioning/v1/services/" + serviceID + "/security/allowlist")
-	if err != nil {
-		return nil, err
-	}
-	if resp.IsError() {
-		return nil, handleError(resp)
-	}
-	response := *resp.Result().(*provisioning.ReadAllowListResponse)
+	var result []provisioning.AllowListItem
+	err := c.doWithPendingRetry(ctx, func() error {
+		resp, err := c.HTTPClient.R().
+			SetHeader("Accept", "application/json").
+			SetResult(provisioning.ReadAllowListResponse{}).
+			SetError(&ErrorResponse{}).
+			SetContext(ctx).
+			SetBody(allowlist).
+			Put("/provisioning/v1/services/" + serviceID + "/security/allowlist")
+		if err != nil {
+			return err
+		}
+		if resp.IsError() {
+			return handleError(resp)
+		}
+		response := *resp.Result().(*provisioning.ReadAllowListResponse)
+		result = response[0].AllowList
+		return nil
+	})
 
-	return response[0].AllowList, err
+	return result, err
 }
 
 func (c *Client) ReadServiceAllowListByID(ctx context.Context, serviceID string) (provisioning.ReadAllowListResponse, error) {
@@ -225,36 +240,56 @@ func (c *Client) ReadServiceAllowListByID(ctx context.Context, serviceID string)
 }
 
 func handleError(resp *resty.Response) error {
-	if resp.StatusCode() == 404 {
+	if resp.StatusCode() == http.StatusNotFound {
 		return ErrorServiceNotFound
 	}
-	if resp.StatusCode() == 401 {
+	if resp.StatusCode() == http.StatusUnauthorized {
 		return ErrorUnauthorized
 	}
+
+	detail := ""
 	if resp.Error() != nil {
-		errResp, ok := resp.Error().(*ErrorResponse)
-		if ok && len(errResp.Errors) > 0 {
-			return fmt.Errorf("SkySQL API %d: %s", resp.StatusCode(), errResp.Errors[0].Message)
+		if errResp, ok := resp.Error().(*ErrorResponse); ok && len(errResp.Errors) > 0 {
+			detail = errResp.Errors[0].Message
 		}
+	}
+
+	// Classify the DPS status-gate rejection (service is mid-operation) into a
+	// single sentinel so mutating calls can wait it out and retry (MCDEV-3899).
+	// Current DPS returns it as a 400 with a distinctive message; newer DPS
+	// returns a 409 Conflict. Matching the status (and the legacy message for
+	// backward compatibility) keeps detection off the fragile message string.
+	if resp.StatusCode() == http.StatusConflict ||
+		strings.Contains(strings.ToLower(detail), pendingStateMarker) {
+		if detail != "" {
+			return fmt.Errorf("%w (SkySQL API %d: %s)", ErrorServiceInPendingState, resp.StatusCode(), detail)
+		}
+		return fmt.Errorf("%w (SkySQL API %d)", ErrorServiceInPendingState, resp.StatusCode())
+	}
+
+	if detail != "" {
+		return fmt.Errorf("SkySQL API %d: %s", resp.StatusCode(), detail)
 	}
 	return fmt.Errorf("SkySQL API error: %s", resp.Status())
 }
 
 func (c *Client) SetServicePowerState(ctx context.Context, serviceID string, isActive bool) error {
-	resp, err := c.HTTPClient.R().
-		SetHeader("Accept", "application/json").
-		SetContext(ctx).
-		SetBody(&provisioning.PowerStateRequest{IsActive: isActive}).
-		SetError(&ErrorResponse{}).
-		Post("/provisioning/v1/services/" + serviceID + "/power")
-	if err != nil {
-		return err
-	}
-	if resp.IsError() {
-		return handleError(resp)
-	}
+	return c.doWithPendingRetry(ctx, func() error {
+		resp, err := c.HTTPClient.R().
+			SetHeader("Accept", "application/json").
+			SetContext(ctx).
+			SetBody(&provisioning.PowerStateRequest{IsActive: isActive}).
+			SetError(&ErrorResponse{}).
+			Post("/provisioning/v1/services/" + serviceID + "/power")
+		if err != nil {
+			return err
+		}
+		if resp.IsError() {
+			return handleError(resp)
+		}
 
-	return err
+		return nil
+	})
 }
 
 func (c *Client) ModifyServiceEndpoints(
@@ -264,96 +299,110 @@ func (c *Client) ModifyServiceEndpoints(
 	allowedAccounts []string,
 	visibility string,
 ) (*provisioning.ServiceEndpoint, error) {
-	resp, err := c.HTTPClient.R().
-		SetHeader("Accept", "application/json").
-		SetContext(ctx).
-		SetBody(&provisioning.PatchServiceEndpointsRequest{
-			{Mechanism: mechanism,
-				AllowedAccounts: allowedAccounts,
-				Visibility:      visibility},
-		}).
-		SetResult(provisioning.PatchServiceEndpointsResponse{}).
-		SetError(&ErrorResponse{}).
-		Patch("/provisioning/v1/services/" + serviceID + "/endpoints")
-	if err != nil {
-		return nil, err
-	}
-	if resp.IsError() {
-		return nil, handleError(resp)
-	}
-	response := *resp.Result().(*provisioning.PatchServiceEndpointsResponse)
-	if response == nil {
-		response = make(provisioning.PatchServiceEndpointsResponse, 0)
-	}
-	return &response[0], err
+	var result *provisioning.ServiceEndpoint
+	err := c.doWithPendingRetry(ctx, func() error {
+		resp, err := c.HTTPClient.R().
+			SetHeader("Accept", "application/json").
+			SetContext(ctx).
+			SetBody(&provisioning.PatchServiceEndpointsRequest{
+				{Mechanism: mechanism,
+					AllowedAccounts: allowedAccounts,
+					Visibility:      visibility},
+			}).
+			SetResult(provisioning.PatchServiceEndpointsResponse{}).
+			SetError(&ErrorResponse{}).
+			Patch("/provisioning/v1/services/" + serviceID + "/endpoints")
+		if err != nil {
+			return err
+		}
+		if resp.IsError() {
+			return handleError(resp)
+		}
+		response := *resp.Result().(*provisioning.PatchServiceEndpointsResponse)
+		if response == nil {
+			response = make(provisioning.PatchServiceEndpointsResponse, 0)
+		}
+		result = &response[0]
+		return nil
+	})
+
+	return result, err
 }
 
 func (c *Client) ModifyServiceSize(ctx context.Context, serviceID string, size string) error {
-	resp, err := c.HTTPClient.R().
-		SetHeader("Accept", "application/json").
-		SetContext(ctx).
-		SetBody(&provisioning.UpdateServiceSizeRequest{Size: size}).
-		SetError(&ErrorResponse{}).
-		Post("/provisioning/v1/services/" + serviceID + "/size")
-	if err != nil {
-		return err
-	}
-	if resp.IsError() {
-		return handleError(resp)
-	}
+	return c.doWithPendingRetry(ctx, func() error {
+		resp, err := c.HTTPClient.R().
+			SetHeader("Accept", "application/json").
+			SetContext(ctx).
+			SetBody(&provisioning.UpdateServiceSizeRequest{Size: size}).
+			SetError(&ErrorResponse{}).
+			Post("/provisioning/v1/services/" + serviceID + "/size")
+		if err != nil {
+			return err
+		}
+		if resp.IsError() {
+			return handleError(resp)
+		}
 
-	return err
+		return nil
+	})
 }
 
 func (c *Client) ModifyServiceNodeNumber(ctx context.Context, serviceID string, nodes int64) error {
-	resp, err := c.HTTPClient.R().
-		SetHeader("Accept", "application/json").
-		SetContext(ctx).
-		SetBody(&provisioning.UpdateServiceNodesNumberRequest{Nodes: nodes}).
-		SetError(&ErrorResponse{}).
-		Post("/provisioning/v1/services/" + serviceID + "/nodes")
-	if err != nil {
-		return err
-	}
-	if resp.IsError() {
-		return handleError(resp)
-	}
+	return c.doWithPendingRetry(ctx, func() error {
+		resp, err := c.HTTPClient.R().
+			SetHeader("Accept", "application/json").
+			SetContext(ctx).
+			SetBody(&provisioning.UpdateServiceNodesNumberRequest{Nodes: nodes}).
+			SetError(&ErrorResponse{}).
+			Post("/provisioning/v1/services/" + serviceID + "/nodes")
+		if err != nil {
+			return err
+		}
+		if resp.IsError() {
+			return handleError(resp)
+		}
 
-	return err
+		return nil
+	})
 }
 
 func (c *Client) ModifyServiceStorage(ctx context.Context, serviceID string, size int64, iops int64, throughput int64) error {
-	resp, err := c.HTTPClient.R().
-		SetHeader("Accept", "application/json").
-		SetContext(ctx).
-		SetBody(&provisioning.UpdateStorageRequest{Size: size, IOPS: iops, Throughput: throughput}).
-		SetError(&ErrorResponse{}).
-		Patch("/provisioning/v1/services/" + serviceID + "/storage")
-	if err != nil {
-		return err
-	}
-	if resp.IsError() {
-		return handleError(resp)
-	}
+	return c.doWithPendingRetry(ctx, func() error {
+		resp, err := c.HTTPClient.R().
+			SetHeader("Accept", "application/json").
+			SetContext(ctx).
+			SetBody(&provisioning.UpdateStorageRequest{Size: size, IOPS: iops, Throughput: throughput}).
+			SetError(&ErrorResponse{}).
+			Patch("/provisioning/v1/services/" + serviceID + "/storage")
+		if err != nil {
+			return err
+		}
+		if resp.IsError() {
+			return handleError(resp)
+		}
 
-	return err
+		return nil
+	})
 }
 
 func (c *Client) UpdateServiceTags(ctx context.Context, serviceID string, tags map[string]string) error {
-	resp, err := c.HTTPClient.R().
-		SetHeader("Accept", "application/json").
-		SetContext(ctx).
-		SetBody(&provisioning.UpdateServiceTagsRequest{Tags: tags}).
-		SetError(&ErrorResponse{}).
-		Patch("/provisioning/v1/services/" + serviceID + "/tags")
-	if err != nil {
-		return err
-	}
-	if resp.IsError() {
-		return handleError(resp)
-	}
+	return c.doWithPendingRetry(ctx, func() error {
+		resp, err := c.HTTPClient.R().
+			SetHeader("Accept", "application/json").
+			SetContext(ctx).
+			SetBody(&provisioning.UpdateServiceTagsRequest{Tags: tags}).
+			SetError(&ErrorResponse{}).
+			Patch("/provisioning/v1/services/" + serviceID + "/tags")
+		if err != nil {
+			return err
+		}
+		if resp.IsError() {
+			return handleError(resp)
+		}
 
-	return err
+		return nil
+	})
 }
 
 func (c *Client) SetAutonomousActions(
@@ -527,34 +576,38 @@ func (c *Client) SetConfigValue(ctx context.Context, configID string, variableNa
 }
 
 func (c *Client) ApplyConfigToService(ctx context.Context, serviceID string, configID string) error {
-	resp, err := c.HTTPClient.R().
-		SetHeader("Accept", "application/json").
-		SetError(&ErrorResponse{}).
-		SetContext(ctx).
-		SetBody(&provisioning.ServiceConfigState{ConfigID: configID}).
-		Post("/provisioning/v1/services/" + serviceID + "/config")
-	if err != nil {
-		return err
-	}
-	if resp.IsError() {
-		return handleError(resp)
-	}
-	return nil
+	return c.doWithPendingRetry(ctx, func() error {
+		resp, err := c.HTTPClient.R().
+			SetHeader("Accept", "application/json").
+			SetError(&ErrorResponse{}).
+			SetContext(ctx).
+			SetBody(&provisioning.ServiceConfigState{ConfigID: configID}).
+			Post("/provisioning/v1/services/" + serviceID + "/config")
+		if err != nil {
+			return err
+		}
+		if resp.IsError() {
+			return handleError(resp)
+		}
+		return nil
+	})
 }
 
 func (c *Client) RemoveConfigFromService(ctx context.Context, serviceID string) error {
-	resp, err := c.HTTPClient.R().
-		SetHeader("Accept", "application/json").
-		SetError(&ErrorResponse{}).
-		SetContext(ctx).
-		Delete("/provisioning/v1/services/" + serviceID + "/config")
-	if err != nil {
-		return err
-	}
-	if resp.IsError() {
-		return handleError(resp)
-	}
-	return nil
+	return c.doWithPendingRetry(ctx, func() error {
+		resp, err := c.HTTPClient.R().
+			SetHeader("Accept", "application/json").
+			SetError(&ErrorResponse{}).
+			SetContext(ctx).
+			Delete("/provisioning/v1/services/" + serviceID + "/config")
+		if err != nil {
+			return err
+		}
+		if resp.IsError() {
+			return handleError(resp)
+		}
+		return nil
+	})
 }
 
 func (c *Client) GetConfigKeysByTopology(ctx context.Context, topologyName string, version string) ([]provisioning.ConfigKey, error) {

--- a/internal/skysql/errors.go
+++ b/internal/skysql/errors.go
@@ -24,3 +24,12 @@ type ErrorDetails struct {
 var ErrorServiceNotFound = errors.New("service not found")
 
 var ErrorUnauthorized = errors.New("skysql returns unauthorized error")
+
+// ErrorServiceInPendingState indicates the backend (DPS status gate,
+// ensureThatServiceStatusAllowsUpdates) rejected a mutating operation because
+// the target service is currently in a pending_* state — another operation is
+// already in flight. DPS surfaces this as a 400 with a distinctive message in
+// current versions and as a 409 Conflict in newer ones; handleError classifies
+// both into this sentinel so mutating calls can wait it out and retry
+// (see doWithPendingRetry, MCDEV-3899).
+var ErrorServiceInPendingState = errors.New("service is in a pending state")

--- a/internal/skysql/pending_retry.go
+++ b/internal/skysql/pending_retry.go
@@ -1,0 +1,76 @@
+package skysql
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Defaults for waiting out a transient "service is in a pending state"
+// rejection. The backend (dbprovision-service ensureThatServiceStatusAllowsUpdates)
+// returns HTTP 400 with the message "service modification not allowed while
+// service is in a pending state" whenever a mutating operation reaches a service
+// while an earlier scale/config/power operation is still in flight. The HTTP
+// layer does not retry 400s, so without this the later operation fails outright
+// (MCDEV-3899). The rejection clears once the in-flight operation finishes, so
+// we poll until the service is modifiable again.
+const (
+	defaultPendingRetryInterval = 10 * time.Second
+	defaultPendingRetryTimeout  = 30 * time.Minute
+)
+
+// pendingStateMarker is the stable, distinctive fragment of the backend's
+// legacy 400 pending-state rejection message. handleError uses it to classify
+// that form (newer DPS returns a 409 Conflict instead) into
+// ErrorServiceInPendingState.
+const pendingStateMarker = "pending state"
+
+// isPendingStateError reports whether err is the backend's rejection of a
+// mutating operation because the target service is currently in a pending_*
+// state. handleError classifies both the legacy 400 message and the newer 409
+// Conflict into ErrorServiceInPendingState; the error resolves once the
+// in-flight operation completes, so retrying is safe and desirable.
+func isPendingStateError(err error) bool {
+	return errors.Is(err, ErrorServiceInPendingState)
+}
+
+// doWithPendingRetry runs fn and, when it fails only because the service is in a
+// pending state, waits and retries until the operation is accepted, fn fails for
+// another reason, ctx is cancelled, or the configured timeout elapses. This
+// serializes operations issued close together (for example a config change and a
+// scaling operation) instead of failing the later one.
+func (c *Client) doWithPendingRetry(ctx context.Context, fn func() error) error {
+	interval := c.pendingRetryInterval
+	if interval <= 0 {
+		interval = defaultPendingRetryInterval
+	}
+	timeout := c.pendingRetryTimeout
+	if timeout <= 0 {
+		timeout = defaultPendingRetryTimeout
+	}
+
+	deadline := time.Now().Add(timeout)
+	for attempt := 1; ; attempt++ {
+		err := fn()
+		if !isPendingStateError(err) {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("service was still in a pending state after %s: %w", timeout, err)
+		}
+
+		tflog.Debug(ctx, "service is in a pending state, waiting before retrying the operation", map[string]interface{}{
+			"attempt":  attempt,
+			"retry_in": interval.String(),
+		})
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}

--- a/internal/skysql/pending_retry.go
+++ b/internal/skysql/pending_retry.go
@@ -3,7 +3,6 @@ package skysql
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -37,40 +36,23 @@ func isPendingStateError(err error) bool {
 	return errors.Is(err, ErrorServiceInPendingState)
 }
 
-// doWithPendingRetry runs fn and, when it fails only because the service is in a
-// pending state, waits and retries until the operation is accepted, fn fails for
-// another reason, ctx is cancelled, or the configured timeout elapses. This
-// serializes operations issued close together (for example a config change and a
-// scaling operation) instead of failing the later one.
+// doWithPendingRetry runs fn, retrying while the backend reports the service is
+// in a pending_* state (another operation is in flight), until fn succeeds,
+// fails for another reason, or pendingRetryTimeout elapses. The HTTP request
+// inside fn observes ctx, so a cancelled context ends the loop on the next
+// attempt. This serializes operations issued close together (for example a
+// config change and a scaling operation) instead of failing the later one.
 func (c *Client) doWithPendingRetry(ctx context.Context, fn func() error) error {
-	interval := c.pendingRetryInterval
-	if interval <= 0 {
-		interval = defaultPendingRetryInterval
-	}
-	timeout := c.pendingRetryTimeout
-	if timeout <= 0 {
-		timeout = defaultPendingRetryTimeout
-	}
-
-	deadline := time.Now().Add(timeout)
-	for attempt := 1; ; attempt++ {
+	deadline := time.Now().Add(c.pendingRetryTimeout)
+	for {
 		err := fn()
-		if !isPendingStateError(err) {
+		if !isPendingStateError(err) || time.Now().After(deadline) {
 			return err
 		}
-		if time.Now().After(deadline) {
-			return fmt.Errorf("service was still in a pending state after %s: %w", timeout, err)
-		}
 
-		tflog.Debug(ctx, "service is in a pending state, waiting before retrying the operation", map[string]interface{}{
-			"attempt":  attempt,
-			"retry_in": interval.String(),
+		tflog.Debug(ctx, "service is in a pending state; retrying after a delay", map[string]interface{}{
+			"retry_in": c.pendingRetryInterval.String(),
 		})
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(interval):
-		}
+		time.Sleep(c.pendingRetryInterval)
 	}
 }

--- a/internal/skysql/pending_retry_test.go
+++ b/internal/skysql/pending_retry_test.go
@@ -1,0 +1,214 @@
+package skysql
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// pendingStateMessage mirrors the body dbprovision-service returns today in its
+// 400 pending-state rejection (ErrServiceModificationInPendingState).
+const pendingStateMessage = "service modification not allowed while service is in a pending state"
+
+// pendingErr is what handleError produces once it has classified a pending-state
+// rejection into the sentinel.
+func pendingErr() error {
+	return fmt.Errorf("%w (SkySQL API 400: %s)", ErrorServiceInPendingState, pendingStateMessage)
+}
+
+func TestIsPendingStateError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"classified pending state", pendingErr(), true},
+		{"bare sentinel", ErrorServiceInPendingState, true},
+		{"unrelated validation", errors.New("SkySQL API 400: invalid size sky-99x99"), false},
+		// Detection is by sentinel (set in handleError), not by raw string match.
+		{"raw message is not classified", errors.New(pendingStateMessage), false},
+		{"service not found", ErrorServiceNotFound, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPendingStateError(tc.err); got != tc.want {
+				t.Fatalf("isPendingStateError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDoWithPendingRetry_RetriesUntilSuccess(t *testing.T) {
+	c := &Client{pendingRetryInterval: time.Millisecond, pendingRetryTimeout: time.Second}
+
+	calls := 0
+	err := c.doWithPendingRetry(context.Background(), func() error {
+		calls++
+		if calls < 3 {
+			return pendingErr()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestDoWithPendingRetry_SuccessFirstTry(t *testing.T) {
+	c := &Client{pendingRetryInterval: time.Millisecond, pendingRetryTimeout: time.Second}
+
+	calls := 0
+	if err := c.doWithPendingRetry(context.Background(), func() error { calls++; return nil }); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 call, got %d", calls)
+	}
+}
+
+func TestDoWithPendingRetry_NonPendingReturnsImmediately(t *testing.T) {
+	c := &Client{pendingRetryInterval: time.Millisecond, pendingRetryTimeout: time.Second}
+	other := errors.New("SkySQL API 400: invalid size")
+
+	calls := 0
+	err := c.doWithPendingRetry(context.Background(), func() error { calls++; return other })
+	if !errors.Is(err, other) {
+		t.Fatalf("expected the original error to pass through, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 call (no retry), got %d", calls)
+	}
+}
+
+func TestDoWithPendingRetry_RespectsContextCancellation(t *testing.T) {
+	// Long interval/timeout so the only way out is ctx cancellation.
+	c := &Client{pendingRetryInterval: time.Hour, pendingRetryTimeout: time.Hour}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	calls := 0
+	err := c.doWithPendingRetry(ctx, func() error { calls++; return pendingErr() })
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call before cancellation was observed, got %d", calls)
+	}
+}
+
+func TestDoWithPendingRetry_TimesOut(t *testing.T) {
+	c := &Client{pendingRetryInterval: time.Millisecond, pendingRetryTimeout: 5 * time.Millisecond}
+
+	calls := 0
+	err := c.doWithPendingRetry(context.Background(), func() error { calls++; return pendingErr() })
+	if err == nil {
+		t.Fatal("expected an error after timeout, got nil")
+	}
+	if !isPendingStateError(err) {
+		t.Fatalf("timed-out error should still read as a pending-state error, got %v", err)
+	}
+	if calls < 1 {
+		t.Fatalf("expected at least 1 call, got %d", calls)
+	}
+}
+
+// TestModifyServiceSize_RetriesWhilePending exercises the full client path
+// against current DPS behavior: a scaling call rejected with the pending-state
+// 400 a couple of times, then accepted. This is the MCDEV-3899 race between a
+// config change and a scaling operation.
+func TestModifyServiceSize_RetriesWhilePending(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n < 3 {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(ErrorResponse{
+				Errors: []ErrorDetails{{Message: pendingStateMessage}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]string{"id": "svc-123"})
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.pendingRetryInterval = time.Millisecond
+	client.pendingRetryTimeout = 5 * time.Second
+
+	if err := client.ModifyServiceSize(context.Background(), "svc-123", "sky-4x16"); err != nil {
+		t.Fatalf("expected success after pending-state retries, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 attempts (2 pending + 1 accepted), got %d", got)
+	}
+}
+
+// TestModifyServiceSize_RetriesOn409Conflict exercises forward compatibility
+// with the planned DPS change: a 409 Conflict is retried even though its body
+// does not mention a pending state — detection is by status, not message.
+func TestModifyServiceSize_RetriesOn409Conflict(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n < 3 {
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(ErrorResponse{
+				Errors: []ErrorDetails{{Message: "operation already in progress"}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]string{"id": "svc-123"})
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.pendingRetryInterval = time.Millisecond
+	client.pendingRetryTimeout = 5 * time.Second
+
+	if err := client.ModifyServiceSize(context.Background(), "svc-123", "sky-4x16"); err != nil {
+		t.Fatalf("expected success after 409 retries, got %v", err)
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 attempts (2 conflict + 1 accepted), got %d", got)
+	}
+}
+
+// TestModifyServiceSize_DoesNotRetryValidation400 guards against the wrapper
+// masking real client errors: a genuine validation 400 must fail immediately.
+func TestModifyServiceSize_DoesNotRetryValidation400(t *testing.T) {
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(ErrorResponse{
+			Errors: []ErrorDetails{{Message: "invalid size sky-99x99"}},
+		})
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "test-key", "")
+	client.pendingRetryInterval = time.Millisecond
+	client.pendingRetryTimeout = 5 * time.Second
+
+	if err := client.ModifyServiceSize(context.Background(), "svc-123", "sky-99x99"); err == nil {
+		t.Fatal("expected a validation error, got nil")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected exactly 1 attempt (no retry on validation 400), got %d", got)
+	}
+}

--- a/internal/skysql/pending_retry_test.go
+++ b/internal/skysql/pending_retry_test.go
@@ -90,19 +90,26 @@ func TestDoWithPendingRetry_NonPendingReturnsImmediately(t *testing.T) {
 	}
 }
 
-func TestDoWithPendingRetry_RespectsContextCancellation(t *testing.T) {
-	// Long interval/timeout so the only way out is ctx cancellation.
-	c := &Client{pendingRetryInterval: time.Hour, pendingRetryTimeout: time.Hour}
+func TestDoWithPendingRetry_StopsWhenContextCancelled(t *testing.T) {
+	c := &Client{pendingRetryInterval: time.Millisecond, pendingRetryTimeout: time.Minute}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	calls := 0
-	err := c.doWithPendingRetry(ctx, func() error { calls++; return pendingErr() })
+	// The HTTP request inside fn observes ctx, so once cancelled it fails fast
+	// with a context error rather than another pending-state error.
+	err := c.doWithPendingRetry(ctx, func() error {
+		calls++
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return pendingErr()
+	})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 	if calls != 1 {
-		t.Fatalf("expected 1 call before cancellation was observed, got %d", calls)
+		t.Fatalf("expected 1 call, got %d", calls)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes the customer-reported race where a config change and a scaling operation on the same service conflict and one fails (MCDEV-3899).

DPS rejects any mutating call while a service is in a `pending_*` state (another operation in flight) — today an HTTP 400, soon a 409 Conflict (separate dbprovision-service PR). The HTTP retry layer doesn't retry those, so the second operation failed the apply.

- All nine service-mutating client calls (size, nodes, storage, config apply/remove, power, endpoints, tags, allowlist) now wait out the pending-state rejection and retry until the service is modifiable again — default 10s interval, 30m cap, honoring the request context.
- `handleError` classifies both the legacy 400-with-message and the forthcoming 409 Conflict into `ErrorServiceInPendingState`, so detection is by status/type, not a fragile message match. Works against current DPS; does not depend on the DPS change.
- Genuine validation 400s are unaffected (not retried).
